### PR TITLE
Add BFS visualization to intermediate algorithms

### DIFF
--- a/src/components/2_Intermediate_Algos/BfsAlgo.jsx
+++ b/src/components/2_Intermediate_Algos/BfsAlgo.jsx
@@ -1,24 +1,296 @@
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Container,
   CardContainer,
   Title,
   AlgoVisualizer,
-  CodeBlock
-} from "../../Styled Components/styledComponents";
+  CodeBlock,
+  Para
+} from "../Styled Components/styledComponents";
 
-import React from "react";
-import useStore from "../../ZustandStore";
+const graphData = {
+  nodes: [
+    { id: "A", x: 100, y: 60 },
+    { id: "B", x: 250, y: 40 },
+    { id: "C", x: 400, y: 60 },
+    { id: "D", x: 150, y: 160 },
+    { id: "E", x: 300, y: 170 },
+    { id: "F", x: 450, y: 160 }
+  ],
+  edges: [
+    { from: "A", to: "B" },
+    { from: "A", to: "D" },
+    { from: "B", to: "C" },
+    { from: "B", to: "E" },
+    { from: "C", to: "F" },
+    { from: "D", to: "E" },
+    { from: "E", to: "F" }
+  ]
+};
+
+const buildAdjacencyList = (edges) => {
+  const adjacency = new Map();
+  edges.forEach(({ from, to }) => {
+    if (!adjacency.has(from)) {
+      adjacency.set(from, []);
+    }
+    if (!adjacency.has(to)) {
+      adjacency.set(to, []);
+    }
+    adjacency.get(from).push(to);
+    adjacency.get(to).push(from);
+  });
+  return adjacency;
+};
+
+const generateBfsSteps = (graph, startNode) => {
+  const adjacency = buildAdjacencyList(graph.edges);
+  const visited = new Set();
+  const queue = [startNode];
+  const traversal = [];
+  const steps = [
+    {
+      currentNode: null,
+      queue: [...queue],
+      visited: [],
+      traversal: [],
+      activeEdge: null,
+      message: `Start at ${startNode}, enqueue it.`
+    }
+  ];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    traversal.push(current);
+    steps.push({
+      currentNode: current,
+      queue: [...queue],
+      visited: [...visited],
+      traversal: [...traversal],
+      activeEdge: null,
+      message: `Dequeue ${current} and mark it visited.`
+    });
+
+    const neighbors = adjacency.get(current) ?? [];
+    neighbors.forEach((neighbor) => {
+      if (!visited.has(neighbor) && !queue.includes(neighbor)) {
+        queue.push(neighbor);
+        steps.push({
+          currentNode: current,
+          queue: [...queue],
+          visited: [...visited],
+          traversal: [...traversal],
+          activeEdge: { from: current, to: neighbor },
+          message: `Visit neighbor ${neighbor}, enqueue it.`
+        });
+      }
+    });
+  }
+
+  steps.push({
+    currentNode: null,
+    queue: [],
+    visited: [...visited],
+    traversal: [...traversal],
+    activeEdge: null,
+    message: "Queue empty. BFS complete."
+  });
+
+  return steps;
+};
 
 const BfsAlgo = () => {
+  const steps = useMemo(() => generateBfsSteps(graphData, "A"), []);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(true);
+
+  useEffect(() => {
+    if (!isPlaying || stepIndex >= steps.length - 1) {
+      return undefined;
+    }
+
+    const intervalId = setInterval(() => {
+      setStepIndex((prev) => Math.min(prev + 1, steps.length - 1));
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [isPlaying, stepIndex, steps.length]);
+
+  const currentStep = steps[stepIndex];
+  const nodesById = useMemo(() => {
+    return graphData.nodes.reduce((acc, node) => {
+      acc[node.id] = node;
+      return acc;
+    }, {});
+  }, []);
+
+  const nodeColor = (nodeId) => {
+    if (currentStep.currentNode === nodeId) {
+      return "#e74c3c";
+    }
+    if (currentStep.visited.includes(nodeId)) {
+      return "#2ecc71";
+    }
+    if (currentStep.queue.includes(nodeId)) {
+      return "#f1c40f";
+    }
+    return "#95a5a6";
+  };
+
   return (
     <Container>
       <CardContainer>
-        <Title>Bfs Algo</Title>
+        <Title>BFS (Breadth-First Search)</Title>
+        <Para>
+          Breadth-First Search explores a graph level by level using a queue. It
+          visits all neighbors of the current node before moving deeper, making
+          it ideal for shortest paths in unweighted graphs.
+        </Para>
         <AlgoVisualizer>
+          <div style={{
+            display: "flex",
+            justifyContent: "space-between",
+            gap: "24px",
+            width: "100%",
+            flexWrap: "wrap"
+          }}>
+            <div style={{ flex: "2 1 420px" }}>
+              <svg width="600" height="240" viewBox="0 0 600 240">
+                {graphData.edges.map((edge) => {
+                  const from = nodesById[edge.from];
+                  const to = nodesById[edge.to];
+                  const isActive =
+                    currentStep.activeEdge &&
+                    ((currentStep.activeEdge.from === edge.from &&
+                      currentStep.activeEdge.to === edge.to) ||
+                      (currentStep.activeEdge.from === edge.to &&
+                        currentStep.activeEdge.to === edge.from));
+                  return (
+                    <line
+                      key={`${edge.from}-${edge.to}`}
+                      x1={from.x}
+                      y1={from.y}
+                      x2={to.x}
+                      y2={to.y}
+                      stroke={isActive ? "#e67e22" : "#bdc3c7"}
+                      strokeWidth={isActive ? 4 : 2}
+                    />
+                  );
+                })}
+                {graphData.nodes.map((node) => (
+                  <g key={node.id}>
+                    <circle cx={node.x} cy={node.y} r={22} fill={nodeColor(node.id)} />
+                    <text
+                      x={node.x}
+                      y={node.y + 5}
+                      textAnchor="middle"
+                      fontSize="16px"
+                      fill="#ffffff"
+                      fontWeight="bold"
+                    >
+                      {node.id}
+                    </text>
+                  </g>
+                ))}
+              </svg>
+            </div>
+            <div style={{ flex: "1 1 220px" }}>
+              <div style={{ marginBottom: "12px" }}>
+                <strong>Queue:</strong>
+                <div
+                  style={{
+                    marginTop: "8px",
+                    padding: "10px",
+                    background: "#ecf0f1",
+                    borderRadius: "6px",
+                    minHeight: "40px"
+                  }}
+                >
+                  {currentStep.queue.length > 0
+                    ? currentStep.queue.join(" → ")
+                    : "(empty)"}
+                </div>
+              </div>
+              <div style={{ marginBottom: "12px" }}>
+                <strong>Traversal order:</strong>
+                <div
+                  style={{
+                    marginTop: "8px",
+                    padding: "10px",
+                    background: "#ecf0f1",
+                    borderRadius: "6px",
+                    minHeight: "40px"
+                  }}
+                >
+                  {currentStep.traversal.length > 0
+                    ? currentStep.traversal.join(" → ")
+                    : "(none yet)"}
+                </div>
+              </div>
+              <div style={{ marginBottom: "12px" }}>
+                <strong>Step:</strong>
+                <div style={{ marginTop: "8px" }}>{currentStep.message}</div>
+              </div>
+              <div style={{ display: "flex", gap: "10px" }}>
+                <button
+                  type="button"
+                  onClick={() => setIsPlaying((prev) => !prev)}
+                  style={{
+                    padding: "8px 14px",
+                    borderRadius: "6px",
+                    border: "1px solid #bdc3c7",
+                    background: "#ffffff",
+                    cursor: "pointer"
+                  }}
+                >
+                  {isPlaying ? "Pause" : "Play"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStepIndex(0);
+                    setIsPlaying(true);
+                  }}
+                  style={{
+                    padding: "8px 14px",
+                    borderRadius: "6px",
+                    border: "1px solid #bdc3c7",
+                    background: "#ffffff",
+                    cursor: "pointer"
+                  }}
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
+          </div>
         </AlgoVisualizer>
-          <CodeBlock>
-            { ` ` }
-          </CodeBlock>
+        <CodeBlock>
+{`function bfs(graph, start) {
+  const queue = [start];
+  const visited = new Set();
+  const order = [];
+
+  while (queue.length > 0) {
+    const node = queue.shift();
+    if (visited.has(node)) continue;
+    visited.add(node);
+    order.push(node);
+
+    for (const neighbor of graph[node]) {
+      if (!visited.has(neighbor)) {
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return order;
+}`}
+        </CodeBlock>
       </CardContainer>
     </Container>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import BubbleSortAlgo from "../components/1_Beginner_Algos/BubbleSortAlgo";
 import CountingSortAlgo from "../components/1_Beginner_Algos/CountingSortAlgo";
 import EuclideanAlgorithmAlgo from "../components/1_Beginner_Algos/EuclideanAlgorithmAlgo";
 import FibonacciSequenceIterativeAlgo from "../components/1_Beginner_Algos/FibonacciSequenceIterativeAlgo";
+import BfsAlgo from "../components/2_Intermediate_Algos/BfsAlgo";
 
 const Home = () => {
   return (
@@ -18,6 +19,7 @@ const Home = () => {
       <CountingSortAlgo />
       <EuclideanAlgorithmAlgo />
       <FibonacciSequenceIterativeAlgo endOnValue={200} />
+      <BfsAlgo />
     </div>
   );
 } 


### PR DESCRIPTION
### Motivation
- Provide an interactive BFS visualization that demonstrates queue operations, traversal order, and edge/node highlighting for intermediate algorithm learners.
- Make the new BFS visualizer accessible from the Home page so it can be viewed alongside other algorithm demos.

### Description
- Implemented a full BFS visualizer in `src/components/2_Intermediate_Algos/BfsAlgo.jsx` with graph data, adjacency builder, step generator, playback controls, SVG rendering, queue and traversal panels, and a code sample block.
- Fixed the styled-components import to `../Styled Components/styledComponents` and used the `Para` and `CodeBlock` exports for explanatory text and code formatting.
- Added `import BfsAlgo from "../components/2_Intermediate_Algos/BfsAlgo"` and rendered `<BfsAlgo />` in `src/pages/Home.jsx` for quick access.
- Changes were staged and committed to the repository.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, indicating the app served successfully.
- Ran a Playwright script that navigated to `http://127.0.0.1:4173/` and captured a screenshot `artifacts/bfs-visualizer.png` of the rendered page.
- An initial import resolution error for the styled-components path was observed while testing and was corrected, after which the dev server started without errors.
- All automated steps (dev server start and Playwright run) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883347b364832595f31e305fe8ec46)